### PR TITLE
Better error message for bad format strings

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -298,8 +298,23 @@ function log_(msgArgs, level) {
     return e !== null && type === 'object' ? JSON.stringify(e, null, JSON_SPACES) : e;
   });
   
-  var msg =  (typeof msgArgs[0] == 'string' || msgArgs[0] instanceof String) ? Utilities.formatString.apply(this, args) : msgArgs[0];  
-  
+  var msg = msgArgs[0];
+  if (typeof msgArgs[0] == 'string' || msgArgs[0] instanceof String) {
+    try {
+      msg = Utilities.formatString.apply(this, args)
+    } catch (error) {
+      if (error.message === 'Not enough arguments') {
+        if (msgArgs.length === 2 && Array.isArray(msgArgs[1])) {
+          throw Error('Format string requires multiple arguments and only a single array passed in.');
+        } else {
+          throw Error('Not enough arguments passed in for given format string.');
+        }
+      } else {
+        throw(error);
+      }
+    }
+  }
+
   //default console logging (built in with Google Apps Script's View > Logs...)
   nativeLogger_.log(convertUsingDefaultPatternLayout_(msg, level));
   


### PR DESCRIPTION
I just ran into an issue where I was calling `Logger.log('test %s %s', [42, 43])` and getting a "`Not enough arguments`" error from within `replacerDemuxer`.   This is my fault (I didn't know `log` was variadic and assumed the second arg should have been an array (I don't really know javascript)).  I see that this issue has come up for others (#24, #25), so I figured this patch might help.

- `Logger.log('test %s %s', [42, 43])` will throw "Format string requires multiple arguments and only a single array passed in."
- `Logger.log('test %s %s', 42)` will throw "Not enough arguments passed in for given format string."
- ...and all other errors in `Utilities.formatString` will just re-raise.
